### PR TITLE
[IS-46] refactor: update address model

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -11,7 +11,7 @@ class AddressesController < ApplicationController
 
   def new
     request.variant = :drawer
-    @address = MexicanAddress.new
+    @address = Address.new
   end
 
   def edit
@@ -19,7 +19,7 @@ class AddressesController < ApplicationController
   end
 
   def create # rubocop:disable Metrics/AbcSize
-    @address = MexicanAddress.new(address_params).tap { it.user = current_user }
+    @address = Address.new(address_params).tap { it.user = current_user }
 
     begin
       if create_address(@address, address_params)
@@ -54,7 +54,7 @@ class AddressesController < ApplicationController
 
   def address_params
     params.expect(
-      mexican_address: %i[
+      address: %i[
         country_id postal_code state_id city_id neighborhood street_and_number reference full_name phone_number default
       ]
     )

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -6,9 +6,9 @@ class Address < ApplicationRecord
   belongs_to :state, class_name: 'Country::State'
   belongs_to :city, class_name: 'Country::State::City'
 
-  normalizes :street_level1, with: ->(value) { value.capitalize }
+  normalizes :street_and_number, with: ->(value) { value.capitalize }
 
-  validates :postal_code, :full_name, :street_level1, presence: true
+  validates :postal_code, :full_name, :street_and_number, presence: true
 
   delegate :name, to: :state, prefix: true, allow_nil: true
   delegate :name, to: :city, prefix: true, allow_nil: true

--- a/app/models/mexican_address.rb
+++ b/app/models/mexican_address.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-class MexicanAddress < Address
-  alias_attribute :street_and_number, :street_level1
-end

--- a/app/views/addresses/edit.html+drawer.erb
+++ b/app/views/addresses/edit.html+drawer.erb
@@ -1,6 +1,6 @@
 <%= render 'drawer' do %>
   <div class="relative mt-6 flex-1 px-4 flex flex-col gap-6 m-2 sm:m-10" data-controller="addresses--form">
-    <%= form_with(model: @address, url: address_path(id: @address.id), method: :put) do |form| %>
+    <%= form_with(model: @address) do |form| %>
       <h2 class="text-2xl font-bold text-primary-900 dark:text-white mb-4">
         <%= t('title', scope: 'addresses.edit') %>
       </h2>

--- a/db/migrate/20250528170144_change_address_columns.rb
+++ b/db/migrate/20250528170144_change_address_columns.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ChangeAddressColumns < ActiveRecord::Migration[8.0]
+  def up
+    change_table :addresses, bulk: true do |t|
+      t.remove :street_level2, type: :string
+      t.remove :type, type: :string
+      t.rename :street_level1, :street_and_number
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, 'Cannot revert the changes made to the addresses table'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_23_025908) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_28_170144) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   create_table "addresses", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "user_id", null: false
     t.uuid "country_id", null: false
-    t.string "type", null: false
-    t.string "street_level1"
-    t.string "street_level2"
+    t.string "street_and_number"
     t.string "postal_code", null: false
     t.string "reference"
     t.datetime "created_at", null: false

--- a/test/controllers/addresses_controller_test.rb
+++ b/test/controllers/addresses_controller_test.rb
@@ -10,7 +10,7 @@ class AddressesControllerTest < ActionDispatch::IntegrationTest
 
   let(:params) do
     {
-      mexican_address: {
+      address: {
         full_name: 'Luis Silva',
         street_and_number: 'Calle de los libres 107',
         country_id: country.id,
@@ -45,7 +45,7 @@ class AddressesControllerTest < ActionDispatch::IntegrationTest
   end
 
   describe '#GET edit' do
-    let(:address) { create(:mexican_address, :juan_perez_home, user:) }
+    let(:address) { create(:address, :mx, user:) }
 
     test 'returns a 200 response' do
       create(:mx_postal_code, :oaxaca_centro, state:, city:)
@@ -65,7 +65,7 @@ class AddressesControllerTest < ActionDispatch::IntegrationTest
 
     describe 'with invalid params' do
       test 'redirects to the new address page' do
-        params[:mexican_address][:postal_code] = nil
+        params[:address][:postal_code] = nil
         post(addresses_url(format: :turbo_stream), params:)
 
         assert_turbo_stream action: :append, target: 'flash'
@@ -74,7 +74,7 @@ class AddressesControllerTest < ActionDispatch::IntegrationTest
   end
 
   describe '#PATCH update' do
-    let(:address) { create(:mexican_address, :juan_perez_home, user:) }
+    let(:address) { create(:address, :mx, user:) }
 
     describe 'with valid params' do
       test 'redirects to the addresses page' do
@@ -86,7 +86,7 @@ class AddressesControllerTest < ActionDispatch::IntegrationTest
 
     describe 'with invalid params' do
       test 'redirects to the edit address page' do
-        params[:mexican_address][:postal_code] = nil
+        params[:address][:postal_code] = nil
         put(address_url(id: address.id, format: :turbo_stream), params:)
 
         assert_turbo_stream action: :append, target: 'flash'

--- a/test/controllers/checkouts/addresses_controller_test.rb
+++ b/test/controllers/checkouts/addresses_controller_test.rb
@@ -18,7 +18,7 @@ module Checkouts
     end
 
     describe '#PUT update' do
-      let(:address) { create(:mexican_address, user:) }
+      let(:address) { create(:address, :mx, user:) }
 
       test 'updates the default address' do
         put(checkout_address_url(id: address.id, format: :turbo_stream), params: {})

--- a/test/factories/addresses.rb
+++ b/test/factories/addresses.rb
@@ -1,29 +1,30 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :mexican_address, class: 'MexicanAddress' do
+  factory :address do
     user
-    type { 'MexicanAddress' }
     country { Country.find_or_create_by(name: 'México', code: 'MX') }
     state { Country::State.find_or_create_by(name: 'Oaxaca', code: 'OAX', country:) }
     city { Country::State::City.find_or_create_by(name: 'Oaxaca de Juárez', state:) }
     neighborhood { 'Centro' }
-    street_level1 { 'Callejón Donají s/n' }
-    street_level2 { nil }
+    street_and_number { 'Callejón Donají s/n' }
     full_name { 'Luis Silva' }
     postal_code { '70760' }
     reference { 'Portón blanco' }
   end
 
-  trait :juan_perez_home do
+  trait :mx do
+    before(:create) do |address|
+      address.country ||= Country.find_or_create_by(name: 'México', code: 'MX')
+      address.state ||= Country::State.find_or_create_by(name: 'Oaxaca', code: 'OAX', country: address.country)
+      address.city ||= Country::State::City.find_or_create_by(name: 'Oaxaca de Juárez', state: address.state)
+    end
+
+    user { association :user }
     full_name { 'Juan Pérez' }
-    street_level1 { 'Calle de los libres 107' }
+    street_and_number { 'Calle de los libres 107' }
     neighborhood { 'Oaxaca Centro' }
     postal_code { '68000' }
     reference { 'Al lado del estacionamiento' }
-    user { association(:user) }
-    country { Country.find_or_create_by(name: 'México', code: 'MX') }
-    state { Country::State.find_or_create_by(name: 'Oaxaca', code: 'OAX') }
-    city { Country::State::City.find_or_create_by(name: 'Oaxaca de Juárez', state:) }
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
 
   trait :with_default_address do
     after(:create) do |user|
-      create(:mexican_address, user: user, default: true)
+      create(:address, :mx, user: user, default: true)
     end
   end
 end

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -2,11 +2,11 @@
 
 require 'test_helper'
 
-class MexicanAddressTest < ActiveSupport::TestCase
-  let(:mx_address) { build(:mexican_address) }
+class AddressTest < ActiveSupport::TestCase
+  let(:mx_address) { build(:address, :mx) }
 
   test 'builds a valid mexican address' do
-    assert build(:mexican_address).valid?
+    assert build(:address, :mx).valid?
   end
 
   describe '#validations' do
@@ -22,8 +22,8 @@ class MexicanAddressTest < ActiveSupport::TestCase
       assert mx_address.invalid?
     end
 
-    test 'validates presence of street_level1' do
-      mx_address.street_level1 = nil
+    test 'validates presence of street_and_number' do
+      mx_address.street_and_number = nil
 
       assert mx_address.invalid?
     end


### PR DESCRIPTION
Identify addresss by its country relationship

Remove `MexicanAddress` class and only keep `Addres` class
Remove `street_level2` and `type` columns and rename `street_level1` to `street_and_number`